### PR TITLE
Update Ansible scripts to use Pogo 9.6.1

### DIFF
--- a/ansible/roles/deploy_tangobox/tasks/main.yml
+++ b/ansible/roles/deploy_tangobox/tasks/main.yml
@@ -152,21 +152,21 @@
     - deploy-tangobox-tango-java
 
 #################################
-# Download and copy Pogo 9.6.0
+# Download and copy Pogo
 #################################
 
 
-- name: Download Pogo 9.6.0
+- name: Download Pogo 9.6.1
   get_url:
-     url=https://bintray.com/tango-controls/maven/download_file?file_path=org%2Ftango%2Ftools%2Fpogo%2Fgui%2FPogo%2F9.6.0%2FPogo-9.6.0.jar
+     url=https://bintray.com/tango-controls/maven/download_file?file_path=org%2Ftango%2Ftools%2Fpogo%2Fgui%2FPogo%2F9.6.1%2FPogo-9.6.1.jar
      dest=/usr/share/java/
   tags:
     - tango-java
     - deploy-tangobox-tango-java
     - deploy-tangobox-tango-java-pogo
 
-- name: Create symlink /user/share/java/org.tango.pogo.jar to Pogo 9.6.0
-  file: src=/usr/share/java/Pogo-9.6.0.jar  dest=/usr/share/java/org.tango.pogo.jar state=link
+- name: Create symlink /user/share/java/org.tango.pogo.jar to Pogo 9.6.1
+  file: src=/usr/share/java/Pogo-9.6.1.jar  dest=/usr/share/java/org.tango.pogo.jar state=link
   tags:
     - tango-java
     - deploy-tangobox-tango-java


### PR DESCRIPTION
9.6.0 has an issue when generating new classes in PythonHL mode - this is fixed in 9.6.1