### PR TITLE
Create groups object on SKABaseDevice startup

### DIFF
--- a/skabase/SKABaseDevice/SKABaseDevice/SKABaseDevice.py
+++ b/skabase/SKABaseDevice/SKABaseDevice/SKABaseDevice.py
@@ -28,7 +28,8 @@ import json
 from PyTango import DeviceProxy
 
 from skabase.utils import (get_dp_command, exception_manager,
-                           tango_type_conversion, coerce_value)
+                           tango_type_conversion, coerce_value,
+                           get_groups_from_json)
 
 # PROTECTED REGION END #    //  SKABaseDevice.additionnal_import
 
@@ -271,6 +272,12 @@ class SKABaseDevice(Device):
     def init_device(self):
         Device.init_device(self)
         # PROTECTED REGION ID(SKABaseDevice.init_device) ENABLED START #
+
+        # create TANGO Groups objects dict, according to property
+        self.debug_stream("Groups definitions: {}".format(self.GroupDefinitions))
+        self.groups = get_groups_from_json(self.GroupDefinitions)
+        self.info_stream("Groups loaded: {}".format(sorted(self.groups.keys())))
+
         # PROTECTED REGION END #    //  SKABaseDevice.init_device
 
     def always_executed_hook(self):

--- a/skabase/tests/test_utils.py
+++ b/skabase/tests/test_utils.py
@@ -159,6 +159,11 @@ def bad_group_configs(request):
 def test_get_groups_from_json_empty_list():
     groups = get_groups_from_json([])
     assert groups == {}
+    # empty or whitespace strings should also be ignored
+    groups = get_groups_from_json([''])
+    assert groups == {}
+    groups = get_groups_from_json(['  ', '', ' '])
+    assert groups == {}
 
 
 def _validate_group(definition, group):

--- a/skabase/utils.py
+++ b/skabase/utils.py
@@ -327,7 +327,8 @@ def get_groups_from_json(json_definitions):
 
     Each string in the list is a JSON serialised dict defining the "group_name",
     "devices" and "subgroups" in the group.  The tango.Group() created enables
-    easy access to the managed devices in bulk, or individually.
+    easy access to the managed devices in bulk, or individually. Empty and
+    whitespace-only strings will be ignored.
 
     The general format of the list is as follows, with optional "devices" and
     "subgroups" keys:
@@ -369,10 +370,11 @@ def get_groups_from_json(json_definitions):
 
     Returns
     -------
-    groups: dict or None
+    groups: dict
         The keys of the dict are the names of the groups, in the following form:
             {"<group name 1>": <tango.Group>,
              "<group name 2>": <tango.Group>, ...}.
+        Will be an empty dict if no groups were specified.
 
     Raises
     ------
@@ -390,10 +392,12 @@ def get_groups_from_json(json_definitions):
         # Parse and validate user's definitions
         groups = {}
         for json_definition in json_definitions:
-            definition = json_loads_byteified(json_definition)
-            _validate_group(definition)
-            group_name = definition['group_name']
-            groups[group_name] = _build_group(definition)
+            json_definition = json_definition.strip()
+            if json_definition:
+                definition = json_loads_byteified(json_definition)
+                _validate_group(definition)
+                group_name = definition['group_name']
+                groups[group_name] = _build_group(definition)
         return groups
 
     except Exception as exc:


### PR DESCRIPTION
Read the GroupsDefinition property and create a `self.groups` object accordingly when the device server starts up.  The object is not used yet, but there is some TANGO logging to show basic info about the groups.

Updated the utility that parses the JSON to ignore empty strings, since an empty property will still have at least one empty string item.

JIRA: [LMC-429](https://skaafrica.atlassian.net/browse/LMC-429)

### Example, using a test device

I set `GroupDefintions` property as below - note that each group definition must be a provided as a single line:
```
{"group_name": "g1", "devices": ["sys/tg_test/1", "sys/database/2"]}
{"group_name": "g2", "devices": ["sys/access_control/1", "sys/tg_test/1"]}
{"group_name": "g3",  "subgroups": [{"group_name": "g3.a", "devices": ["sys/access_control/1", "sys/tg_test/1"]},  {"group_name": "g3.b", "devices": ["sys/database/2"]}] }
```
Then starting up the test device, with debug level logging enabled:
```
kat@levpro.deva2.camlab.kat.ac.za:~$ SKATestDevice test -v4
1508922944 [140141749655360] DEBUG ska/test/0 Groups definitions: ['{"group_name": "g1", "devices": ["sys/tg_test/1", "sys/database/2"]}', '{"group_name": "g2", "devices": ["sys/access_control/1", "sys/tg_test/1"]}', '{"group_name": "g3",  "subgroups": [{"group_name": "g3.a", "devices": ["sys/access_control/1", "sys/tg_test/1"]},  {"group_name": "g3.b", "devices": ["sys/database/2"]}] }']
1508922944 [140141749655360] INFO ska/test/0 Groups loaded: ['g1', 'g2', 'g3']
Ready to accept request
```