### PR TITLE
Add RunGroupCommand to SKATestDevice as an example

### DIFF
--- a/skabase/SKATestDevice/SKATestDevice.xmi
+++ b/skabase/SKATestDevice/SKATestDevice.xmi
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ASCII"?>
 <pogoDsl:PogoSystem xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:pogoDsl="http://www.esrf.fr/tango/pogo/PogoDsl">
-  <classes name="SKATestDevice" pogoRevision="9.5">
-    <description description="A generic Test device for testing SKA base class functionalites." title="SKATestDevice" sourcePath="/Users/lvdheever/link-devl5/git/levpro/skabase/SKATestDevice" language="PythonHL" filestogenerate="XMI   file,Code files,Python Package,Protected Regions" license="GPL" copyright="" hasMandatoryProperty="false" hasConcreteProperty="false" hasAbstractCommand="true" hasAbstractAttribute="false">
+  <classes name="SKATestDevice" pogoRevision="9.6">
+    <description description="A generic Test device for testing SKA base class functionalites." title="SKATestDevice" sourcePath="/home/kat/git/levpro/skabase/SKATestDevice" language="PythonHL" filestogenerate="XMI   file,Code files,Python Package,Protected Regions" license="GPL" copyright="" hasMandatoryProperty="false" hasConcreteProperty="false" hasAbstractCommand="true" hasAbstractAttribute="false">
       <inheritances classname="Device_Impl" sourcePath=""/>
       <inheritances classname="SKABaseDevice" sourcePath="../SKABaseDevice"/>
       <identification contact="at ska.ac.za - cam" author="cam" emailDomain="ska.ac.za" classFamily="OtherInstruments" siteSpecific="" platform="All Platforms" bus="Not Applicable" manufacturer="SKASA" reference="SKA-SKATestDevice"/>
@@ -41,7 +41,7 @@
       <status abstract="false" inherited="true" concrete="true"/>
       <DefaultPropValue>healthState,adminMode,controlMode</DefaultPropValue>
     </deviceProperties>
-    <deviceProperties name="GroupDefinitions" description="List of grouped devices managed by a master.  Each string in the array is a JSON &#xA;document defining the ``groupname``, ``devices`` and ``groups`` in the group.&#xA;A proxy client will be opened for each of the managed devices.&#xA;A group will be instantiated for the managed devices per group.&#xA;Each entry in the array contains a JSON defining the group, like:&#xA;[ {``groupname``: ``group1``, &#xA;    ``devices``: ``csv list of devices in group1``},&#xA;  {``groupname``: ``group2``, # a group with devices and a subgroup&#xA;    ``devices``: ``csv list of devices in group2``,&#xA;     ``groups`` : ``csv list of sub groups``},&#xA;  {``groupname``: ``group3``, &#xA;     ``devices`` : ``csv list of devices in group3``}},&#xA;  {``groupname``: ``group4``, # a group with only subgroups&#xA;    ``groups`` : ``csv list of sub groups``}}]&#xA;&#xA;e.g. for a hierarchy of racks, servers and switches&#xA;[{ ``groupname``: ``servers``, &#xA;   ``devices``: ``elt/server/1,elt/server/2,elt/server/3,elt/server/4``},&#xA;  {``groupname``: ``switches``, &#xA;    ``devices``: ``elt/switch/A,elt/switch/B``},&#xA;  {``groupname``: ``pdus``, &#xA;    ``devices``: ``elt/pdu/rackA,elt/pdu/rackB``},&#xA;  {``groupname``:``rackA``, &#xA;    ``devices``: ``elt/server/1,elt/server/2,elt/switch/A,elt/pdu/rackA``},&#xA;  {``groupname``:``rackB``,&#xA;    ``devices``: ``elt/server/3,elt/server/4,elt/switch/B,elt/pdu/rackB``},&#xA;  {``groupname``:``racks``,&#xA;     ``groups``: ``rackA,rackB``}]">
+    <deviceProperties name="GroupDefinitions" description="Each string in the list is a JSON serialised dict defining the ``group_name``,&#xA;``devices`` and ``subgroups`` in the group.  A TANGO Group object is created&#xA;for each item in the list, according to the hierarchy defined.  This provides&#xA;easy access to the managed devices in bulk, or individually.&#xA;&#xA;The general format of the list is as follows, with optional ``devices`` and&#xA;``subgroups`` keys:&#xA;    [ {``group_name``: ``&lt;name>``,&#xA;       ``devices``: [``&lt;dev name>``, ...]},&#xA;      {``group_name``: ``&lt;name>``,&#xA;       ``devices``: [``&lt;dev name>``, ``&lt;dev name>``, ...],&#xA;       ``subgroups`` : [{&lt;nested group>},&#xA;                              {&lt;nested group>}, ...]},&#xA;      ...&#xA;      ]&#xA;&#xA;For example, a hierarchy of racks, servers and switches:&#xA;    [ {``group_name``: ``servers``,&#xA;       ``devices``: [``elt/server/1``, ``elt/server/2``,&#xA;                       ``elt/server/3``, ``elt/server/4``]},&#xA;      {``group_name``: ``switches``,&#xA;       ``devices``: [``elt/switch/A``, ``elt/switch/B``]},&#xA;      {``group_name``: ``pdus``,&#xA;       ``devices``: [``elt/pdu/rackA``, ``elt/pdu/rackB``]},&#xA;      {``group_name``: ``racks``,&#xA;      ``subgroups``: [&#xA;            {``group_name``: ``rackA``,&#xA;             ``devices``: [``elt/server/1``, ``elt/server/2``,&#xA;                               ``elt/switch/A``, ``elt/pdu/rackA``]},&#xA;            {``group_name``: ``rackB``,&#xA;             ``devices``: [``elt/server/3``, ``elt/server/4``,&#xA;                              ``elt/switch/B``, ``elt/pdu/rackB``],&#xA;             ``subgroups``: []}&#xA;       ]} ]">
       <type xsi:type="pogoDsl:StringVectorType"/>
       <status abstract="false" inherited="true" concrete="true"/>
     </deviceProperties>
@@ -111,6 +111,15 @@
         <type xsi:type="pogoDsl:ConstStringType"/>
       </argout>
       <status abstract="true" inherited="true" concrete="true"/>
+    </commands>
+    <commands name="RunGroupCommand" description="Runs the specified command on the specified group and returns&#xA;the results." execMethod="run_group_command" displayLevel="OPERATOR" polledPeriod="0" isDynamic="false">
+      <argin description="JSON encoded dict with this format&#xA;{``group``: str,  # name of existing group&#xA;  ``command``: str, # name of command to run&#xA;  ``arg_type``: str,  # data type of command input argument&#xA;  ``arg_value``: str, # value for command input argument&#xA;  ``forward``: bool  # True if command should be forwarded to all subgroups (default)&#xA;}">
+        <type xsi:type="pogoDsl:StringType"/>
+      </argin>
+      <argout description="Return value from command on the group, as a JSON encoded string.&#xA;This will be a list of dicts of the form &#xA;[ &#xA;{``device_name``: str,  # TANGO device name&#xA;  ``argout``: &lt;value>,  # return value from command (type depends on command)&#xA;  ``failed``: bool  # True if command failed&#xA;},&#xA;{ ... },&#xA; ... ]">
+        <type xsi:type="pogoDsl:StringType"/>
+      </argout>
+      <status abstract="false" inherited="false" concrete="true" concreteHere="true"/>
     </commands>
     <attributes name="obsState" attType="Scalar" rwType="READ" displayLevel="OPERATOR" polledPeriod="0" maxX="" maxY="" allocReadMember="true" isDynamic="false">
       <dataType xsi:type="pogoDsl:EnumType"/>
@@ -202,27 +211,38 @@
       <status abstract="false" inherited="true" concrete="true"/>
       <properties description="The test mode of the device. &#xA;Either no test mode (empty string) or an indication of the test mode." label="" unit="" standardUnit="" displayUnit="" format="" maxValue="" minValue="" maxAlarm="" minAlarm="" maxWarning="" minWarning="" deltaTime="" deltaValue=""/>
     </attributes>
-    <states name="ON" description="">
+    <states name="ON" description="This state could have been called OK or OPERATIONAL. It means that the device is in its operational state. (E.g. the power supply is giving its nominal current, th motor is ON and ready to move, the instrument is operating). This state is modified by the Attribute alarm checking of the DeviceImpl:dev_state method. i.e. if the State is ON and one attribute has its quality factor to ATTR_WARNING or ATTR_ALARM, then the State is modified to ALARM.">
       <status abstract="false" inherited="true" concrete="true"/>
     </states>
-    <states name="OFF" description="">
+    <states name="OFF" description="The device is in normal condition but is not active. E.g. the power supply main circuit breaker is open; the RF transmitter has no power etc...">
       <status abstract="false" inherited="true" concrete="true"/>
     </states>
-    <states name="FAULT" description="">
+    <states name="FAULT" description="The device has a major failure that prevents it to work. For instance, A power supply has stopped due to over temperature A motor cannot move because it has fault conditions. Usually we cannot get out from this state without an intervention on the hardware or a reset command.">
       <status abstract="false" inherited="true" concrete="true"/>
     </states>
-    <states name="INIT" description="">
+    <states name="INIT" description="This state is reserved to the starting phase of the device server. It means that the software is not fully operational and that the user must wait">
       <status abstract="false" inherited="true" concrete="true"/>
     </states>
-    <states name="ALARM" description="">
+    <states name="ALARM" description="ALARM - The device is operating but&#xA;at least one of the attributes is out of range. It can be linked to alarm conditions set by attribute properties or a specific case. (E.g. temperature alarm on a stepper motor, end switch pressed on a stepper motor, up water level in a tank, etc....). In alarm, usually the device does its job, but the operator has to perform an action to avoid a bigger problem that may switch the state to FAULT.">
       <status abstract="false" inherited="true" concrete="true"/>
     </states>
-    <states name="UNKNOWN" description="">
+    <states name="UNKNOWN" description="The device cannot retrieve its state. It is the case when there is a communication problem to the hardware (network cut, broken cable etc...) It could also represent an incoherent situation">
       <status abstract="false" inherited="true" concrete="true"/>
     </states>
-    <states name="STANDBY" description="Equates to LOW-POWER mode.&#xA;This is the initial transition from INIT &#xA;if the device supports a low-power mode.">
+    <states name="STANDBY" description="Equates to LOW-POWER mode. This is the initial transition from INIT if the device supports a low-power mode. The device is not fully active but is ready to operate.">
       <status abstract="false" inherited="true" concrete="true"/>
     </states>
-    <preferences docHome="./doc_html" makefileHome="$(TANGO_HOME)"/>
+    <states name="DISABLE" description="The device cannot be switched ON for an external reason. E.g. the power supply has its door open, the safety conditions are not satisfactory to allow the device to operate.">
+      <status abstract="false" inherited="true" concrete="true"/>
+    </states>
+    <preferences docHome="./doc_html" makefileHome="/usr/share/pogo/preferences"/>
+    <overlodedPollPeriodObject name="centralLoggingLevel" type="attribute" pollPeriod="0"/>
+    <overlodedPollPeriodObject name="elementLoggingLevel" type="attribute" pollPeriod="0"/>
+    <overlodedPollPeriodObject name="storageLoggingLevel" type="attribute" pollPeriod="0"/>
+    <overlodedPollPeriodObject name="healthState" type="attribute" pollPeriod="0"/>
+    <overlodedPollPeriodObject name="adminMode" type="attribute" pollPeriod="0"/>
+    <overlodedPollPeriodObject name="controlMode" type="attribute" pollPeriod="0"/>
+    <overlodedPollPeriodObject name="simulationMode" type="attribute" pollPeriod="0"/>
+    <overlodedPollPeriodObject name="testMode" type="attribute" pollPeriod="0"/>
   </classes>
 </pogoDsl:PogoSystem>

--- a/skabase/SKATestDevice/test/SKATestDevice_test.py
+++ b/skabase/SKATestDevice/test/SKATestDevice_test.py
@@ -99,6 +99,12 @@ class SKATestDeviceDeviceTestCase(DeviceTestCase):
         self.device.Status()
         # PROTECTED REGION END #    //  SKATestDevice.test_Status
 
+    def test_RunGroupCommand(self):
+        """Test for RunGroupCommand"""
+        # PROTECTED REGION ID(SKATestDevice.test_RunGroupCommand) ENABLED START #
+        self.device.RunGroupCommand("")
+        # PROTECTED REGION END #    //  SKATestDevice.test_RunGroupCommand
+
     def test_obsState(self):
         """Test for obsState"""
         # PROTECTED REGION ID(SKATestDevice.test_obsState) ENABLED START #


### PR DESCRIPTION
This is just to test the group functionality via a command.  May move this command to the SKABaseDevice in future.

### Example, using SKATestDevice
Note: GroupDefinitions property must be configured as shown.

```
kat@levpro.deva2.camlab.kat.ac.za:~$ itango
ITango 9.2.2 -- An interactive Tango client.
...
In [1]: import json

In [2]: dp = DeviceProxy('ska/test/0')

In [3]: dp.get_property('GroupDefinitions')
Out[3]: {'GroupDefinitions': ['{"group_name": "g1", "devices": ["sys/tg_test/1", "sys/database/2"]}', '{"group_name": "g2", "devices": ["sys/access_control/1", "sys/tg_test/1"]}', '{"group_name": "g3",  "subgroups": [{"group_name": "g3.a", "devices": ["sys/access_control/1", "sys/tg_test/1"]},  {"group_name": "g3.b", "devices": ["sys/database/2"]}] }']}

In [4]: input = json.dumps(dict(group='g3', command='state'))

In [5]: result = dp.RunGroupCommand(input)

In [6]: json.loads(result)
Out[6]: 
[{u'argout': u'ON', u'device_name': u'sys/access_control/1', u'failed': False},
 {u'argout': None, u'device_name': u'sys/tg_test/1', u'failed': True},
 {u'argout': u'ON', u'device_name': u'sys/database/2', u'failed': False}]
```


JIRA: [LMC-430](https://skaafrica.atlassian.net/browse/LMC-430)