### PR TITLE
Use apt to install PyTango instead of pip and add some other useful dependencies tha…

### DIFF
--- a/ansible/roles/deploy_tangobox/tasks/main.yml
+++ b/ansible/roles/deploy_tangobox/tasks/main.yml
@@ -132,20 +132,20 @@
     - libtango-dev
     - liblog4tango-dev
     - liblog4tango-doc
-    - python-enum34
-    - python-guiqwt
-    - python-h5py
-    - python-lxml
+#    - python-enum34
+#    - python-guiqwt
+#    - python-h5py
+#    - python-lxml
 ##    - python-pint
-    - python-ply
+#    - python-ply
 ##    - python-pytango
-    - python-qt4
-    - python-qwt5-qt4
-    - python-spyderlib
+#    - python-qt4
+#    - python-qwt5-qt4
+#    - python-spyderlib
 ##    - python-pymca5
-    - qt4-designer
+#    - qt4-designer
 ##    - python-sphinx-rtd-theme
-    - graphviz
+###############################################    - graphviz
 ##    - python-pyqtgraph
 
   tags:


### PR DESCRIPTION
…t is required to start playing with taurus

Will test and cleanup the commented packages that was not found shortly.
Also busy with further testing on a fresh devl5 (but thought others may find this branch useful in the mean time)