### PR TITLE
Add POGO and other Java tools to Dockerfile

### DIFF
--- a/ansible/roles/generate_sw/tasks/main.yml
+++ b/ansible/roles/generate_sw/tasks/main.yml
@@ -12,15 +12,13 @@
 ##     Pip install working directories
 ###########################################
 
-
-
 - block:
   - name: Generate skabase
     command: pogo -src {{item}}.xmi
     args:
         chdir: "{{software_root}}/levpro/skabase/{{item}}"
     environment:
-        DISPLAY: "localhost:10.0"
+        DISPLAY: "localhost:1.0"
     with_items:
       - SKABaseDevice
       - SKAObsDevice
@@ -39,7 +37,7 @@
     args:
         chdir: "{{software_root}}/levpro/refelt/refelt"
     environment:
-        DISPLAY: "localhost:10.0"
+        DISPLAY: "localhost:1.0"
     with_items:
       - RefMaster
       - RefA

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -119,6 +119,17 @@ RUN pip install itango \
                 "six>=1.9.0" \
                 tango-admin
 
+# Install tango java tools like pogo and jive
+RUN apt-get update \
+ && apt-get install -y default-jre \
+                       liblog4j1.2-java
+RUN wget 'https://people.debian.org/~picca/libtango-java_9.2.5a-1_all.deb' -P /tmp/ \
+ && dpkg -i /tmp/libtango-java_9.2.5a-1_all.deb \
+ && rm -f /tmp/libtango-java_9.2.5a-1_all.deb \
+ && wget 'https://bintray.com/tango-controls/maven/download_file?file_path=org%2Ftango%2Ftools%2Fpogo%2Fgui%2FPogo%2F9.6.1%2FPogo-9.6.1.jar' \
+          -O /usr/share/java/Pogo-9.6.1.jar \
+ && ln -sfv /usr/share/java/Pogo-9.6.1.jar /usr/share/java/org.tango.pogo.jar
+
 # Install virtual monitor
 RUN apt-get install -y xvfb
 


### PR DESCRIPTION
We need Pogo to do the Ansible `generate-sw` role.

Note that the graphical displays of these applications will not be
visible as they are handled by the offscreen X virtual frame buffer (Xvfb).  You need
to set up X11 forwarding to your host if you want to see the windows,
however this is not required for the code generation step.

The RUN step has an additional `apt-get update` to make building this
easier without having to invalidate the whole image cache.

JIRA: LMC-441