### PR TITLE
Starting the tango-db using the nohup command.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,6 +44,9 @@ node('docker') {
                             '''
                             
                             catchError {
+                                // start the mysql and tango-db daemons
+                                sh 'nohup service mysql start'
+                                sh 'nohup service tango-db start'
                                 // run tests
                                 sh '''
                                     python setup.py test \


### PR DESCRIPTION
Some tests were raising this error `API_CantConnectToDatabase` because the tango-db was not running. 