### PR TITLE
Pin pip and update setuptools in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -146,6 +146,9 @@ RUN useradd -ms /bin/bash tango-cs \
  && echo "tango-cs ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/tango-cs \
  && chmod 0440 /etc/sudoers.d/tango-cs
 
+# create ipython profile to so that itango doesn't fail if ipython hasn't run yet
+RUN su tango-cs -c 'ipython profile create'
+
 # Create mount point, so we can create more files here when inside container,
 # with external volume mounted
 RUN mkdir /home/tango-cs/src \


### PR DESCRIPTION
Changes to pip and/or setuptools caused the Docker image build to fail with an error like this:

```
error in pytango setup command: 'install_requires' must be a string
or list of strings containing valid project/version requirement
specifiers
```

Older pip and new setuptools is working.  Also removed `tango-admin` package - not sure why it was there since it is related to Django, not TANGO Controls.  It was also failing to install.

Note that the reference element simulators won't work with [tango-simlib](https://github.com/ska-sa/tango-simlib) 0.1.6 (current release).  A new release should be out very soon - suggest only building the Docker image after that release.  If you are not using the simulated reference element device servers, then this doesn't matter much.  As a workaround, you could manually install from the master branch.