### PR TITLE
ST-127 semver compliance

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,7 @@
 # GitLab CI in conjunction with GitLab Runner can use Docker Engine to test and build any application.
 # Docker, when used with GitLab CI, runs each job in a separate and isolated container using the predefined image that is set up in .gitlab-ci.yml.
 # In this case we use the latest python docker image to build and test this project.
-image: nexus.engageska-portugal.pt/ska-docker/tango-builder:latest
+image: nexus.engageska-portugal.pt/ska-docker/ska-python-buildenv:latest
 
 variables:
   DOCKER_DRIVER: overlay2
@@ -15,11 +15,6 @@ cache:
   paths:
     - build
 
-# before_script is used to define the command that should be run before all jobs, including deploy jobs, but after the restoration of artifacts.
-# This can be an array or a multi-line string.
-before_script:
-  - docker login -u $DOCKER_REGISTRY_USER_LOGIN -p $CI_REGISTRY_PASS_LOGIN $CI_NX_REGISTRY
-
 # The YAML file defines a set of jobs with constraints stating when they should be run.
 # You can specify an unlimited number of jobs which are defined as top-level elements with an arbitrary name and always have to contain at least the script clause.
 # In this case we have only the test job which produce an artifacts (it must be placed into a directory called "public")
@@ -32,16 +27,10 @@ stages:
   - pages
 
 build wheel for publication: # Executed on a tag
-  image: nexus.engageska-portugal.pt/ska-docker/ska-python-buildenv:latest
-  before_script:
-    - ''
   stage: build
   tags:
     - docker-executor
   script:
-    #- apt install -y python3-pip
-    #- pip3 install setuptools
-    #- python3 setup.py egg_info -b+$CI_COMMIT_SHORT_SHA sdist bdist_wheel
     - python setup.py egg_info -b+$CI_COMMIT_SHORT_SHA sdist bdist_wheel
   only:
     - tags
@@ -50,16 +39,10 @@ build wheel for publication: # Executed on a tag
       - ./dist/
 
 build wheel for development: # Executed on a commit
-  image: nexus.engageska-portugal.pt/ska-docker/ska-python-buildenv:latest
-  before_script:
-    - ''
   stage: build
   tags:
     - docker-executor
   script:
-    #- apt install -y python3-pip
-    #- pip3 install setuptools
-    #- python3 setup.py egg_info -b+dev.$CI_COMMIT_SHORT_SHA sdist bdist_wheel
     - python setup.py egg_info -b+dev.$CI_COMMIT_SHORT_SHA sdist bdist_wheel
   except:
     - tags
@@ -69,6 +52,9 @@ build wheel for development: # Executed on a commit
 
 run tests:
   stage: test
+  image: nexus.engageska-portugal.pt/ska-docker/tango-builder:latest
+  before_script:
+  - docker login -u $DOCKER_REGISTRY_USER_LOGIN -p $CI_REGISTRY_PASS_LOGIN $CI_NX_REGISTRY
   tags:
     - docker-executor
   script:
@@ -86,7 +72,7 @@ publish to nexus:
     TWINE_PASSWORD: $TWINE_PASSWORD
   script:
     # check metadata requirements
-    - apt install -y python3-pip
+    - which pip3
     - scripts/validate-metadata.sh
     - pip3 install twine
     - twine upload --repository-url $PYPI_REPOSITORY_URL dist/*

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,7 @@
 # GitLab CI in conjunction with GitLab Runner can use Docker Engine to test and build any application.
 # Docker, when used with GitLab CI, runs each job in a separate and isolated container using the predefined image that is set up in .gitlab-ci.yml.
 # In this case we use the latest python docker image to build and test this project.
-image: nexus.engageska-portugal.pt/ska-docker/tango-builder:latest
+image: nexus.engageska-portugal.pt/ska-docker/ska-python-buildenv:latest
 
 variables:
   DOCKER_DRIVER: overlay2
@@ -36,9 +36,7 @@ build wheel for publication: # Executed on a tag
   tags:
     - docker-executor
   script:
-    - apt install -y python3-pip
-    - pip3 install setuptools
-    - python3 setup.py egg_info -b+$CI_COMMIT_SHORT_SHA sdist bdist_wheel
+    - python setup.py egg_info -b+$CI_COMMIT_SHORT_SHA sdist bdist_wheel
   only:
     - tags
   artifacts:
@@ -50,9 +48,7 @@ build wheel for development: # Executed on a commit
   tags:
     - docker-executor
   script:
-    - apt install -y python3-pip
-    - pip3 install setuptools
-    - python3 setup.py egg_info -b+dev.$CI_COMMIT_SHORT_SHA sdist bdist_wheel
+    - python setup.py egg_info -b+dev.$CI_COMMIT_SHORT_SHA sdist bdist_wheel
   except:
     - tags
   artifacts:
@@ -64,7 +60,6 @@ run tests:
   tags:
     - docker-executor
   script:
-    - apt install -y python3-pip
     - echo $(ls -d ./dist/*.whl | grep $CI_COMMIT_SHORT_SHA)
     - pip3 install -U $(ls -d ./dist/*.whl | grep $CI_COMMIT_SHORT_SHA)
     - make test
@@ -78,7 +73,6 @@ publish to nexus:
     TWINE_PASSWORD: $TWINE_PASSWORD
   script:
     # check metadata requirements
-    - apt install -y python3-pip
     - scripts/validate-metadata.sh
     - pip3 install twine
     - twine upload --repository-url $PYPI_REPOSITORY_URL dist/*

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -85,6 +85,9 @@ publish to nexus:
       - $CI_COMMIT_TAG =~ /^((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)$/ # Confirm semantic versioning of tag
 
 pages:
+  image: nexus.engageska-portugal.pt/ska-docker/tango-builder:latest
+  before_script:
+  - docker login -u $DOCKER_REGISTRY_USER_LOGIN -p $CI_REGISTRY_PASS_LOGIN $CI_NX_REGISTRY
   tags:
     - docker-executor
   stage: pages

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,6 +19,10 @@ cache:
 # This can be an array or a multi-line string.
 before_script:
   - apt-get update
+  - apt-get install -y apt-transport-https ca-certificates curl gnupg2 software-properties-common
+  - curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -
+  - add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable"
+  - apt-get update
   - apt-get install -y docker-ce docker-ce-cli containerd.io
   - docker login -u $DOCKER_REGISTRY_USER_LOGIN -p $CI_REGISTRY_PASS_LOGIN $CI_NX_REGISTRY
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,6 +32,7 @@ stages:
   - pages
 
 build wheel for publication: # Executed on a tag
+  image: nexus.engageska-portugal.pt/ska-docker/ska-python-buildenv:latest
   stage: build
   tags:
     - docker-executor
@@ -46,6 +47,7 @@ build wheel for publication: # Executed on a tag
       - ./dist/
 
 build wheel for development: # Executed on a commit
+  image: nexus.engageska-portugal.pt/ska-docker/ska-python-buildenv:latest
   stage: build
   tags:
     - docker-executor

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,13 +9,6 @@ variables:
 services:
   - docker:dind
 
-# cache is used to specify a list of files and directories which should be cached between jobs. You can only use paths that are within the project workspace.
-# If cache is defined outside the scope of jobs, it means it is set globally and all jobs will use that definition
-cache:
-  paths:
-    - dist
-    - build
-
 # before_script is used to define the command that should be run before all jobs, including deploy jobs, but after the restoration of artifacts.
 # This can be an array or a multi-line string.
 before_script:
@@ -37,8 +30,8 @@ build wheel for publication: # Executed on a tag
   tags:
     - docker-executor
   script:
-    - pip install setuptools
-    - python setup.py egg_info -b+$CI_COMMIT_SHORT_SHA sdist bdist_wheel
+    - pip3 install setuptools
+    - python3 setup.py egg_info -b+$CI_COMMIT_SHORT_SHA sdist bdist_wheel
   only:
     - tags
   artifacts:
@@ -50,8 +43,8 @@ build wheel for development: # Executed on a commit
   tags:
     - docker-executor
   script:
-    - pip install setuptools
-    - python setup.py egg_info -b+dev.$CI_COMMIT_SHORT_SHA sdist bdist_wheel
+    - pip3 install setuptools
+    - python3 setup.py egg_info -b+dev.$CI_COMMIT_SHORT_SHA sdist bdist_wheel
   except:
     - tags
   artifacts:
@@ -64,7 +57,7 @@ run tests:
     - docker-executor
   script:
     - echo $(ls -d ./dist/*.whl | grep $CI_COMMIT_SHORT_SHA)
-    - pip install -U $(ls -d ./dist/*.whl | grep $CI_COMMIT_SHORT_SHA)
+    - pip3 install -U $(ls -d ./dist/*.whl | grep $CI_COMMIT_SHORT_SHA)
     - make test
 
 publish to nexus:
@@ -77,7 +70,7 @@ publish to nexus:
   script:
     # check metadata requirements
     - scripts/validate-metadata.sh
-    - pip install twine
+    - pip3 install twine
     - twine upload --repository-url $PYPI_REPOSITORY_URL dist/*
   only:
     variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,11 +15,6 @@ cache:
   paths:
     - build
 
-# before_script is used to define the command that should be run before all jobs, including deploy jobs, but after the restoration of artifacts.
-# This can be an array or a multi-line string.
-before_script:
-  - docker login -u $DOCKER_REGISTRY_USER_LOGIN -p $CI_REGISTRY_PASS_LOGIN $CI_NX_REGISTRY
-
 # The YAML file defines a set of jobs with constraints stating when they should be run.
 # You can specify an unlimited number of jobs which are defined as top-level elements with an arbitrary name and always have to contain at least the script clause.
 # In this case we have only the test job which produce an artifacts (it must be placed into a directory called "public")

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,7 +30,7 @@ build wheel for publication: # Executed on a tag
   tags:
     - docker-executor
   script:
-    - apt install python3-pip
+    - apt install -y python3-pip
     - pip3 install setuptools
     - python3 setup.py egg_info -b+$CI_COMMIT_SHORT_SHA sdist bdist_wheel
   only:
@@ -44,7 +44,7 @@ build wheel for development: # Executed on a commit
   tags:
     - docker-executor
   script:
-    - apt install python3-pip
+    - apt install -y python3-pip
     - pip3 install setuptools
     - python3 setup.py egg_info -b+dev.$CI_COMMIT_SHORT_SHA sdist bdist_wheel
   except:
@@ -58,7 +58,7 @@ run tests:
   tags:
     - docker-executor
   script:
-    - apt install python3-pip
+    - apt install -y python3-pip
     - echo $(ls -d ./dist/*.whl | grep $CI_COMMIT_SHORT_SHA)
     - pip3 install -U $(ls -d ./dist/*.whl | grep $CI_COMMIT_SHORT_SHA)
     - make test
@@ -72,7 +72,7 @@ publish to nexus:
     TWINE_PASSWORD: $TWINE_PASSWORD
   script:
     # check metadata requirements
-    - apt install python3-pip
+    - apt install -y python3-pip
     - scripts/validate-metadata.sh
     - pip3 install twine
     - twine upload --repository-url $PYPI_REPOSITORY_URL dist/*

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,6 +9,12 @@ variables:
 services:
   - docker:dind
 
+# cache is used to specify a list of files and directories which should be cached between jobs. You can only use paths that are within the project workspace.	
+# If cache is defined outside the scope of jobs, it means it is set globally and all jobs will use that definition
+cache:
+  paths:
+    - build
+
 # before_script is used to define the command that should be run before all jobs, including deploy jobs, but after the restoration of artifacts.
 # This can be an array or a multi-line string.
 before_script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,13 +33,16 @@ stages:
 
 build wheel for publication: # Executed on a tag
   image: nexus.engageska-portugal.pt/ska-docker/ska-python-buildenv:latest
+  before-script:
+    - ''
   stage: build
   tags:
     - docker-executor
   script:
-    - apt install -y python3-pip
-    - pip3 install setuptools
-    - python3 setup.py egg_info -b+$CI_COMMIT_SHORT_SHA sdist bdist_wheel
+    #- apt install -y python3-pip
+    #- pip3 install setuptools
+    #- python3 setup.py egg_info -b+$CI_COMMIT_SHORT_SHA sdist bdist_wheel
+    - python setup.py egg_info -b+$CI_COMMIT_SHORT_SHA sdist bdist_wheel
   only:
     - tags
   artifacts:
@@ -48,13 +51,16 @@ build wheel for publication: # Executed on a tag
 
 build wheel for development: # Executed on a commit
   image: nexus.engageska-portugal.pt/ska-docker/ska-python-buildenv:latest
+  before-script:
+    - ''
   stage: build
   tags:
     - docker-executor
   script:
-    - apt install -y python3-pip
-    - pip3 install setuptools
-    - python3 setup.py egg_info -b+dev.$CI_COMMIT_SHORT_SHA sdist bdist_wheel
+    #- apt install -y python3-pip
+    #- pip3 install setuptools
+    #- python3 setup.py egg_info -b+dev.$CI_COMMIT_SHORT_SHA sdist bdist_wheel
+    - python setup.py egg_info -b+dev.$CI_COMMIT_SHORT_SHA sdist bdist_wheel
   except:
     - tags
   artifacts:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,6 +30,7 @@ build wheel for publication: # Executed on a tag
   tags:
     - docker-executor
   script:
+    - apt install python3-pip
     - pip3 install setuptools
     - python3 setup.py egg_info -b+$CI_COMMIT_SHORT_SHA sdist bdist_wheel
   only:
@@ -43,6 +44,7 @@ build wheel for development: # Executed on a commit
   tags:
     - docker-executor
   script:
+    - apt install python3-pip
     - pip3 install setuptools
     - python3 setup.py egg_info -b+dev.$CI_COMMIT_SHORT_SHA sdist bdist_wheel
   except:
@@ -56,6 +58,7 @@ run tests:
   tags:
     - docker-executor
   script:
+    - apt install python3-pip
     - echo $(ls -d ./dist/*.whl | grep $CI_COMMIT_SHORT_SHA)
     - pip3 install -U $(ls -d ./dist/*.whl | grep $CI_COMMIT_SHORT_SHA)
     - make test
@@ -69,6 +72,7 @@ publish to nexus:
     TWINE_PASSWORD: $TWINE_PASSWORD
   script:
     # check metadata requirements
+    - apt install python3-pip
     - scripts/validate-metadata.sh
     - pip3 install twine
     - twine upload --repository-url $PYPI_REPOSITORY_URL dist/*

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,7 @@
 # GitLab CI in conjunction with GitLab Runner can use Docker Engine to test and build any application.
 # Docker, when used with GitLab CI, runs each job in a separate and isolated container using the predefined image that is set up in .gitlab-ci.yml.
 # In this case we use the latest python docker image to build and test this project.
-image: nexus.engageska-portugal.pt/ska-docker/ska-python-buildenv:latest
+image: nexus.engageska-portugal.pt/ska-docker/tango-builder:latest
 
 variables:
   DOCKER_DRIVER: overlay2
@@ -18,12 +18,6 @@ cache:
 # before_script is used to define the command that should be run before all jobs, including deploy jobs, but after the restoration of artifacts.
 # This can be an array or a multi-line string.
 before_script:
-  - apt-get update
-  - apt-get install -y apt-transport-https ca-certificates curl gnupg2 software-properties-common
-  - curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -
-  - add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable"
-  - apt-get update
-  - apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose
   - docker login -u $DOCKER_REGISTRY_USER_LOGIN -p $CI_REGISTRY_PASS_LOGIN $CI_NX_REGISTRY
 
 # The YAML file defines a set of jobs with constraints stating when they should be run.
@@ -42,7 +36,9 @@ build wheel for publication: # Executed on a tag
   tags:
     - docker-executor
   script:
-    - python setup.py egg_info -b+$CI_COMMIT_SHORT_SHA sdist bdist_wheel
+    - apt install -y python3-pip
+    - pip3 install setuptools
+    - python3 setup.py egg_info -b+$CI_COMMIT_SHORT_SHA sdist bdist_wheel
   only:
     - tags
   artifacts:
@@ -54,7 +50,9 @@ build wheel for development: # Executed on a commit
   tags:
     - docker-executor
   script:
-    - python setup.py egg_info -b+dev.$CI_COMMIT_SHORT_SHA sdist bdist_wheel
+    - apt install -y python3-pip
+    - pip3 install setuptools
+    - python3 setup.py egg_info -b+dev.$CI_COMMIT_SHORT_SHA sdist bdist_wheel
   except:
     - tags
   artifacts:
@@ -66,6 +64,7 @@ run tests:
   tags:
     - docker-executor
   script:
+    - apt install -y python3-pip
     - echo $(ls -d ./dist/*.whl | grep $CI_COMMIT_SHORT_SHA)
     - pip3 install -U $(ls -d ./dist/*.whl | grep $CI_COMMIT_SHORT_SHA)
     - make test
@@ -79,6 +78,7 @@ publish to nexus:
     TWINE_PASSWORD: $TWINE_PASSWORD
   script:
     # check metadata requirements
+    - apt install -y python3-pip
     - scripts/validate-metadata.sh
     - pip3 install twine
     - twine upload --repository-url $PYPI_REPOSITORY_URL dist/*

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,7 +38,7 @@ build wheel for publication: # Executed on a tag
     - docker-executor
   script:
     - pip install setuptools
-    - python setup.py egg_info -b.$CI_COMMIT_SHORT_SHA sdist bdist_wheel
+    - python setup.py egg_info -b+$CI_COMMIT_SHORT_SHA sdist bdist_wheel
   only:
     - tags
   artifacts:
@@ -51,7 +51,7 @@ build wheel for development: # Executed on a commit
     - docker-executor
   script:
     - pip install setuptools
-    - python setup.py egg_info -b.dev.$CI_COMMIT_SHORT_SHA sdist bdist_wheel
+    - python setup.py egg_info -b+dev.$CI_COMMIT_SHORT_SHA sdist bdist_wheel
   except:
     - tags
   artifacts:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,6 +18,7 @@ cache:
 # before_script is used to define the command that should be run before all jobs, including deploy jobs, but after the restoration of artifacts.
 # This can be an array or a multi-line string.
 before_script:
+  - apt-get update
   - apt-get install -y docker-ce docker-ce-cli containerd.io
   - docker login -u $DOCKER_REGISTRY_USER_LOGIN -p $CI_REGISTRY_PASS_LOGIN $CI_NX_REGISTRY
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -63,7 +63,7 @@ run tests:
   tags:
     - docker-executor
   script:
-    - pip install ./dist/*.whl
+    - pip install -U ./dist/*.whl
     - make test
 
 publish to nexus:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,7 +9,7 @@ variables:
 services:
   - docker:dind
 
-# cache is used to specify a list of files and directories which should be cached between jobs. You can only use paths that are within the project workspace.	
+# cache is used to specify a list of files and directories which should be cached between jobs. You can only use paths that are within the project workspace.
 # If cache is defined outside the scope of jobs, it means it is set globally and all jobs will use that definition
 cache:
   paths:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,19 +32,38 @@ stages:
   - publish
   - pages
 
-build wheel:
+build wheel for publication: # Executed on a tag
   stage: build
   tags:
     - docker-executor
   script:
     - pip install setuptools
-    - python setup.py sdist bdist_wheel
+    - python setup.py egg_info -b.$CI_COMMIT_SHORT_SHA sdist bdist_wheel
+  only:
+    - tags
+  artifacts:
+    paths:
+      - ./dist/
+
+build wheel for development: # Executed on a commit
+  stage: build
+  tags:
+    - docker-executor
+  script:
+    - pip install setuptools
+    - python setup.py egg_info -b.dev.$CI_COMMIT_SHORT_SHA sdist bdist_wheel
+  except:
+    - tags
+  artifacts:
+    paths:
+      - ./dist/
 
 run tests:
   stage: test
   tags:
     - docker-executor
   script:
+    - pip install ./dist/*.whl
     - make test
 
 publish to nexus:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,7 +23,7 @@ before_script:
   - curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -
   - add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable"
   - apt-get update
-  - apt-get install -y docker-ce docker-ce-cli containerd.io
+  - apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose
   - docker login -u $DOCKER_REGISTRY_USER_LOGIN -p $CI_REGISTRY_PASS_LOGIN $CI_NX_REGISTRY
 
 # The YAML file defines a set of jobs with constraints stating when they should be run.

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -65,6 +65,9 @@ run tests:
 
 publish to nexus:
   stage: publish
+  image: nexus.engageska-portugal.pt/ska-docker/tango-builder:latest
+  before_script:
+  - docker login -u $DOCKER_REGISTRY_USER_LOGIN -p $CI_REGISTRY_PASS_LOGIN $CI_NX_REGISTRY
   tags:
     - docker-executor
   variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,7 +33,7 @@ stages:
 
 build wheel for publication: # Executed on a tag
   image: nexus.engageska-portugal.pt/ska-docker/ska-python-buildenv:latest
-  before-script:
+  before_script:
     - ''
   stage: build
   tags:
@@ -51,7 +51,7 @@ build wheel for publication: # Executed on a tag
 
 build wheel for development: # Executed on a commit
   image: nexus.engageska-portugal.pt/ska-docker/ska-python-buildenv:latest
-  before-script:
+  before_script:
     - ''
   stage: build
   tags:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -63,7 +63,8 @@ run tests:
   tags:
     - docker-executor
   script:
-    - pip install -U ./dist/*.whl
+    - echo $(ls -d ./dist/*.whl | grep $CI_COMMIT_SHORT_SHA)
+    - pip install -U $(ls -d ./dist/*.whl | grep $CI_COMMIT_SHORT_SHA)
     - make test
 
 publish to nexus:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,6 +15,12 @@ cache:
   paths:
     - build
 
+# before_script is used to define the command that should be run before all jobs, including deploy jobs, but after the restoration of artifacts.
+# This can be an array or a multi-line string.
+before_script:
+  - apt-get install -y docker-ce docker-ce-cli containerd.io
+  - docker login -u $DOCKER_REGISTRY_USER_LOGIN -p $CI_REGISTRY_PASS_LOGIN $CI_NX_REGISTRY
+
 # The YAML file defines a set of jobs with constraints stating when they should be run.
 # You can specify an unlimited number of jobs which are defined as top-level elements with an arbitrary name and always have to contain at least the script clause.
 # In this case we have only the test job which produce an artifacts (it must be placed into a directory called "public")

--- a/scripts/validate-metadata.sh
+++ b/scripts/validate-metadata.sh
@@ -15,7 +15,7 @@ fi
 # TODO: This presently breaks due to setuptools normalizing the package version to something that may not conform to semantic versioning in some cases.
 #       On future versions of setuptools this issue should be solved (a patch was jsut merged) so we can get back to this.
 #       See: https://github.com/pypa/setuptools/issues/308
-if ! python setup.py --version | grep -q -E '^((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)$' ; then
+if ! python setup.py --version | grep -q -E '^(([0-9]+)\.([0-9]+)\.([0-9]+)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)$' ; then
     echo "[warning] metadata: version is not according to versioning standards"
     # exit 2
 fi

--- a/scripts/validate-metadata.sh
+++ b/scripts/validate-metadata.sh
@@ -15,7 +15,7 @@ fi
 # TODO: This presently breaks due to setuptools normalizing the package version to something that may not conform to semantic versioning in some cases.
 #       On future versions of setuptools this issue should be solved (a patch was jsut merged) so we can get back to this.
 #       See: https://github.com/pypa/setuptools/issues/308
-if ! python setup.py --version | grep -q -E '^(([0-9]+)\.([0-9]+)\.([0-9]+)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)$' ; then
+if ! python setup.py --version | grep -q -E '^([0-9]+)\.([0-9]+)\.([0-9]+)$' ; then
     echo "[warning] metadata: version is not according to versioning standards"
     # exit 2
 fi


### PR DESCRIPTION
@flyingfrog81 @jbmorgado 

A step closer to semver compliance.

In `setup.py` you can only have `N.N.N` - validation regex check updated
(I tried all different combinations and keep running into non semver edge cases)

During the CI build:
- for commits I add `+dev.<SHORT-GIT-HASH>`
- for tags I add `+<SHORT-GIT-HASH>`

Check this CI [build](https://gitlab.com/ska-telescope/lmc-base-classes/pipelines/53883549)
In the artefacts we have:
`lmcbaseclasses-0.0.1+dev.ccdd554d-py2-none-any.whl`

The `setuptools` version is (semver compliant):
`"version": "0.0.1+dev.ccdd554d"`

I also added a step in the `test` stage to install the wheel we just built.

Adding the commit hash:
 - Ensures we install the correct one in the test (there's many others carried over in the cache)
 - Gives you a easy reference should you want to check out the code at that exact point for debugging etc.
  


