### PR TITLE
fix conflict between pipenv and test packages

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -28,6 +28,9 @@ Sphinx = "*"
 sphinx_rtd_theme = "*"
 sphinx-autobuild = "*"
 sphinxcontrib-websupport = "*"
+coverage  = "*"
+pytest-xdist = "*"
+mock = "*"
 
 [requires]
 python_version = "3"

--- a/setup.py
+++ b/setup.py
@@ -43,11 +43,6 @@ setuptools.setup(
           "future"
       ],
       tests_require=[
-          "coverage",
-          "pytest",
-          "pytest-cov",
-          "pytest-xdist",
-          "mock"
       ],
       keywords="lmc base classes ska",
       zip_safe=False)

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,5 @@ setuptools.setup(
           "argparse",
           "future"
       ],
-      tests_require=[
-      ],
       keywords="lmc base classes ska",
       zip_safe=False)


### PR DESCRIPTION
Fixes conflict arising between installing the dev packages with *pipenv* and the test harness packages with *pip* when running `python setup.py test` in `make test`.