### PR TITLE
Now using the default ska-python-buildenv image to do the package upload

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -65,9 +65,6 @@ run tests:
 
 publish to nexus:
   stage: publish
-  image: nexus.engageska-portugal.pt/ska-docker/tango-builder:latest
-  before_script:
-  - docker login -u $DOCKER_REGISTRY_USER_LOGIN -p $CI_REGISTRY_PASS_LOGIN $CI_NX_REGISTRY
   tags:
     - docker-executor
   variables:
@@ -75,9 +72,8 @@ publish to nexus:
     TWINE_PASSWORD: $TWINE_PASSWORD
   script:
     # check metadata requirements
-    - which pip3
     - scripts/validate-metadata.sh
-    - pip3 install twine
+    - pip install twine
     - twine upload --repository-url $PYPI_REPOSITORY_URL dist/*
   only:
     variables:


### PR DESCRIPTION
For a tag commit we expect the `whl` file to be upload to the nexus repository. This step failed [here](https://gitlab.com/ska-telescope/lmc-base-classes/pipelines/55424682). 

The reason for that is that we used the `tango-builder` image rather than the `ska-python-buildenv` image, which does not have `pip` available.
I don't think we need to use the `tango-builder` as we only do basic metadata validation and then upload the wheel we created earlier using `twine`
This needs to be tested with another tag commit.