### PR TITLE
ST-227 Refactor lmc-base-classes CI pipeline according to standards

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,6 +23,7 @@ cache:
 stages:
   - build
   - test
+  - linting
   - publish
   - pages
 
@@ -49,6 +50,20 @@ build wheel for development: # Executed on a commit
   artifacts:
     paths:
       - ./dist/
+
+linting:
+  stage: linting
+  image: nexus.engageska-portugal.pt/ska-docker/tango-builder:latest
+  before_script:
+  - docker login -u $DOCKER_REGISTRY_USERNAME -p $DOCKER_REGISTRY_PASSWORD $DOCKER_REGISTRY_HOST
+  tags:
+    - docker-executor
+  script:
+    - apt-get -y update
+    - apt install -y python3-pip
+    - echo $(ls -d ./dist/*.whl | grep $CI_COMMIT_SHORT_SHA)
+    - pip3 install -U $(ls -d ./dist/*.whl | grep $CI_COMMIT_SHORT_SHA)
+    - make lint
 
 run tests:
   stage: test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,7 +23,7 @@ cache:
 stages:
   - build
   - test
-  # - linting
+  - linting
   - publish
   - pages
 
@@ -67,19 +67,19 @@ run tests:
     - scripts/validate-metadata.sh
     - ls build
 
-# linting:
-#   stage: linting
-#   image: nexus.engageska-portugal.pt/ska-docker/tango-builder:latest
-#   before_script:
-#   - docker login -u $DOCKER_REGISTRY_USERNAME -p $DOCKER_REGISTRY_PASSWORD $DOCKER_REGISTRY_HOST
-#   tags:
-#     - docker-executor
-#   script:
-#     - apt-get -y update
-#     - apt install -y python3-pip
-#     - echo $(ls -d ./dist/*.whl | grep $CI_COMMIT_SHORT_SHA)
-#     - pip3 install -U $(ls -d ./dist/*.whl | grep $CI_COMMIT_SHORT_SHA)
-#     - make lint
+linting:
+  stage: linting
+  image: nexus.engageska-portugal.pt/ska-docker/tango-builder:latest
+  before_script:
+  - docker login -u $DOCKER_REGISTRY_USERNAME -p $DOCKER_REGISTRY_PASSWORD $DOCKER_REGISTRY_HOST
+  tags:
+    - docker-executor
+  script:
+    - apt-get -y update
+    - apt install -y python3-pip
+    - echo $(ls -d ./dist/*.whl | grep $CI_COMMIT_SHORT_SHA)
+    - pip3 install -U $(ls -d ./dist/*.whl | grep $CI_COMMIT_SHORT_SHA)
+    # - make lint
 
 publish to nexus:
   stage: publish

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -64,6 +64,7 @@ linting:
     - echo $(ls -d ./dist/*.whl | grep $CI_COMMIT_SHORT_SHA)
     - pip3 install -U $(ls -d ./dist/*.whl | grep $CI_COMMIT_SHORT_SHA)
     - make lint
+    - ls build
 
 run tests:
   stage: test
@@ -79,6 +80,7 @@ run tests:
     - pip3 install -U $(ls -d ./dist/*.whl | grep $CI_COMMIT_SHORT_SHA)
     - make test
     - scripts/validate-metadata.sh
+    - ls build
 
 publish to nexus:
   stage: publish

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -65,7 +65,6 @@ run tests:
     - pip3 install -U $(ls -d ./dist/*.whl | grep $CI_COMMIT_SHORT_SHA)
     - make test
     - scripts/validate-metadata.sh
-    - ls build
 
 linting:
   stage: linting
@@ -80,7 +79,6 @@ linting:
     - echo $(ls -d ./dist/*.whl | grep $CI_COMMIT_SHORT_SHA)
     - pip3 install -U $(ls -d ./dist/*.whl | grep $CI_COMMIT_SHORT_SHA)
     - make lint
-    - ls build
 
 publish to nexus:
   stage: publish
@@ -107,8 +105,6 @@ pages:
     - docker-executor
   stage: pages
   script:
-    - ls
-    - ls build
     - mv build public
     - mv public/lmcbaseclasses_htmlcov/* public
     - make push

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -79,7 +79,8 @@ linting:
     - apt install -y python3-pip
     - echo $(ls -d ./dist/*.whl | grep $CI_COMMIT_SHORT_SHA)
     - pip3 install -U $(ls -d ./dist/*.whl | grep $CI_COMMIT_SHORT_SHA)
-    # - make lint
+    - make lint
+    - ls build
 
 publish to nexus:
   stage: publish

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,7 +23,7 @@ cache:
 stages:
   - build
   - test
-  - linting
+  # - linting
   - publish
   - pages
 
@@ -51,21 +51,6 @@ build wheel for development: # Executed on a commit
     paths:
       - ./dist/
 
-linting:
-  stage: linting
-  image: nexus.engageska-portugal.pt/ska-docker/tango-builder:latest
-  before_script:
-  - docker login -u $DOCKER_REGISTRY_USERNAME -p $DOCKER_REGISTRY_PASSWORD $DOCKER_REGISTRY_HOST
-  tags:
-    - docker-executor
-  script:
-    - apt-get -y update
-    - apt install -y python3-pip
-    - echo $(ls -d ./dist/*.whl | grep $CI_COMMIT_SHORT_SHA)
-    - pip3 install -U $(ls -d ./dist/*.whl | grep $CI_COMMIT_SHORT_SHA)
-    - make lint
-    - ls build
-
 run tests:
   stage: test
   image: nexus.engageska-portugal.pt/ska-docker/tango-builder:latest
@@ -81,6 +66,20 @@ run tests:
     - make test
     - scripts/validate-metadata.sh
     - ls build
+
+# linting:
+#   stage: linting
+#   image: nexus.engageska-portugal.pt/ska-docker/tango-builder:latest
+#   before_script:
+#   - docker login -u $DOCKER_REGISTRY_USERNAME -p $DOCKER_REGISTRY_PASSWORD $DOCKER_REGISTRY_HOST
+#   tags:
+#     - docker-executor
+#   script:
+#     - apt-get -y update
+#     - apt install -y python3-pip
+#     - echo $(ls -d ./dist/*.whl | grep $CI_COMMIT_SHORT_SHA)
+#     - pip3 install -U $(ls -d ./dist/*.whl | grep $CI_COMMIT_SHORT_SHA)
+#     - make lint
 
 publish to nexus:
   stage: publish

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -105,6 +105,8 @@ pages:
     - docker-executor
   stage: pages
   script:
+    - ls
+    - ls build
     - mv build public
     - mv public/lmcbaseclasses_htmlcov/* public
     - make push

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,63 +1,89 @@
 [MASTER]
 
-# Specify a configuration file.
-#rcfile=
-
-# Python code to execute, usually for sys.path manipulation such as
-# pygtk.require().
-init-hook='sys.path.append("./skabase/SKABaseDevice");
-	sys.path.append("./skabase/auxiliary");
-	sys.path.append("./skabase/SKAObsDevice")'
-
-# Profiled execution.
-profile=no
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code.
+extension-pkg-whitelist=
 
 # Add files or directories to the blacklist. They should be base names, not
 # paths.
 ignore=CVS
 
-# Pickle collected data for later comparisons.
-persistent=yes
+# Add files or directories matching the regex patterns to the blacklist. The
+# regex matches against base names, not paths.
+ignore-patterns=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+# FIXME These init-hooks should be removed, they are presently needed due to namespace problems with this repo
+init-hook='sys.path.append("./skabase/SKABaseDevice");
+	sys.path.append("./skabase/auxiliary");
+	sys.path.append("./skabase/SKAObsDevice")'
+
+# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
+# number of processors available to use.
+jobs=0
+
+# Control the amount of potential inferred values when inferring a single
+# object. This can help the performance when dealing with large functions or
+# complex, nested conditions.
+limit-inference-results=100
 
 # List of plugins (as comma separated values of python modules names) to load,
 # usually to register additional checkers.
-load-plugins=
+load-plugins=pylint_junit
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# Specify a configuration file.
+#rcfile=
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages.
+suggestion-mode=yes
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
 
 
 [MESSAGES CONTROL]
 
-# Enable the message, report, category or checker with the given id(s). You can
-# either give multiple identifier separated by comma (,) or put this option
-# multiple time. See also the "--disable" option for examples.
-#enable=
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED.
+confidence=
 
 # Disable the message, report, category or checker with the given id(s). You
 # can either give multiple identifiers separated by comma (,) or put this
 # option multiple times (only on the command line, not in the configuration
-# file where it should appear only once).You can also use "--disable=all" to
+# file where it should appear only once). You can also use "--disable=all" to
 # disable everything first and then reenable specific checks. For example, if
 # you want to run only the similarities checker, you can use "--disable=all
 # --enable=similarities". If you want to run only the classes checker, but have
-# no Warning level messages displayed, use"--disable=all --enable=classes
-# --disable=W"
-disable=C,R,attribute-defined-outside-init,no-member,c-extension-no-member,protected-access,
-        fixme,broad-except,unused-argument,redefined-builtin,invalid-name,bare-except,
-        anomalous-backslash-in-string,redefined-outer-name,undefined-variable,relative-import
+# no Warning level messages displayed, use "--disable=all --enable=classes
+# --disable=W".
+disable=C,
+        R,
+        W
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=unreachable,
+       duplicate-key,
+       unnecessary-semicolon,
+       global-variable-not-assigned,
+       unused-variable,
+       binary-op-exception,
+       bad-format-string,
+       anomalous-backslash-in-string,
+       bad-open-mode
+
 
 [REPORTS]
-
-# Set the output format. Available formats are text, parseable, colorized, msvs
-# (visual studio) and html. You can also give a reporter class, eg
-# mypackage.mymodule.MyReporterClass.
-output-format=text
-
-# Put messages in a separate file for each module / package specified on the
-# command line instead of printing them on stdout. Reports (if any) will be
-# written in a file name "pylint_global.[txt|html]".
-files-output=no
-
-# Tells whether to display a full report or only the messages
-reports=yes
 
 # Python expression which should return a note less than 10 (10 is the highest
 # note). You have access to the variables errors warning, statement which
@@ -66,19 +92,144 @@ reports=yes
 # (RP0004).
 evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
 
-# Add a comment according to your evaluation note. This is used by the global
-# evaluation report (RP0004).
-comment=no
-
 # Template used to display messages. This is a python new-style format string
-# used to format the message information. See doc for all details
+# used to format the message information. See doc for all details.
 #msg-template=
+
+# Set the output format. Available formats are text, parseable, colorized, json
+# and msvs (visual studio). You can also give a reporter class, e.g.
+# mypackage.mymodule.MyReporterClass.
+output-format=junit
+
+# Tells whether to display a full report or only the messages.
+reports=yes
+
+# Activate the evaluation score.
+score=yes
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=sys.exit
+
+
+[BASIC]
+
+# Naming style matching correct argument names.
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style.
+#argument-rgx=
+
+# Naming style matching correct attribute names.
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style.
+#attr-rgx=
+
+# Bad variable names which should always be refused, separated by a comma.
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Naming style matching correct class attribute names.
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style.
+#class-attribute-rgx=
+
+# Naming style matching correct class names.
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-
+# style.
+#class-rgx=
+
+# Naming style matching correct constant names.
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style.
+#const-rgx=
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names.
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style.
+#function-rgx=
+
+# Good variable names which should always be accepted, separated by a comma.
+good-names=i,
+           j,
+           k,
+           ex,
+           Run,
+           _
+
+# Include a hint for the correct naming format with invalid-name.
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names.
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style.
+#inlinevar-rgx=
+
+# Naming style matching correct method names.
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style.
+#method-rgx=
+
+# Naming style matching correct module names.
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style.
+#module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+# These decorators are taken in consideration only for invalid-name.
+property-classes=abc.abstractproperty
+
+# Naming style matching correct variable names.
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style.
+#variable-rgx=
 
 
 [SIMILARITIES]
-
-# Minimum lines number of a similarity.
-min-similarity-lines=4
 
 # Ignore comments when computing similarities.
 ignore-comments=yes
@@ -89,195 +240,253 @@ ignore-docstrings=yes
 # Ignore imports when computing similarities.
 ignore-imports=no
 
-
-[TYPECHECK]
-
-# Tells whether missing members accessed in mixin class should be ignored. A
-# mixin class is detected if its name ends with "mixin" (case insensitive).
-ignore-mixin-members=yes
-
-# List of classes names for which member attributes should not be checked
-# (useful for classes with attributes dynamically set).
-ignored-classes=SQLObject
-
-# When zope mode is activated, add a predefined set of Zope acquired attributes
-# to generated-members.
-zope=no
-
-# List of members which are set dynamically and missed by pylint inference
-# system, and so shouldn't trigger E0201 when accessed. Python regular
-# expressions are accepted.
-generated-members=REQUEST,acl_users,aq_parent
-
-
-[VARIABLES]
-
-# Tells whether we should check for unused import in __init__ files.
-init-import=no
-
-# A regular expression matching the beginning of the name of dummy variables
-# (i.e. not used).
-dummy-variables-rgx=_$|dummy
-
-# List of additional names supposed to be defined in builtins. Remember that
-# you should avoid to define new builtins when possible.
-additional-builtins=
-
-
-[FORMAT]
-
-# Maximum number of characters on a single line.
-max-line-length=110
-
-# Regexp for a line that is allowed to be longer than the limit.
-ignore-long-lines=^\s*(# )?<?https?://\S+>?$
-
-# Allow the body of an if to be on the same line as the test if there is no
-# else.
-single-line-if-stmt=no
-
-# List of optional constructs for which whitespace checking is disabled
-no-space-check=trailing-comma,dict-separator
-
-# Maximum number of lines in a module
-max-module-lines=1000
-
-# String used as indentation unit. This is usually " " (4 spaces) or "\t" (1
-# tab).
-indent-string='    '
-
-
-[BASIC]
-
-# Required attributes for module, separated by a comma
-required-attributes=
-
-# List of builtins function names that should not be used, separated by a comma
-bad-functions=map,filter,apply,input
-
-# Regular expression which should only match correct module names
-module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
-
-# Regular expression which should only match correct module level names
-const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
-
-# Regular expression which should only match correct class names
-class-rgx=[A-Z_][a-zA-Z0-9]+$
-
-# Regular expression which should only match correct function names
-function-rgx=[a-z_][a-z0-9_]{2,30}$
-
-# Regular expression which should only match correct method names
-method-rgx=[a-z_][a-z0-9_]{2,30}$
-
-# Regular expression which should only match correct instance attribute names
-attr-rgx=[a-z_][a-z0-9_]{2,30}$
-
-# Regular expression which should only match correct argument names
-argument-rgx=[a-z_][a-z0-9_]{2,30}$
-
-# Regular expression which should only match correct variable names
-variable-rgx=[a-z_][a-z0-9_]{2,30}$
-
-# Regular expression which should only match correct attribute names in class
-# bodies
-class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
-
-# Regular expression which should only match correct list comprehension /
-# generator expression variable names
-inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
-
-# Good variable names which should always be accepted, separated by a comma
-good-names=i,j,k,ex,Run,_
-
-# Bad variable names which should always be refused, separated by a comma
-bad-names=foo,bar,baz,toto,tutu,tata
-
-# Regular expression which should only match function or class names that do
-# not require a docstring.
-no-docstring-rgx=__.*__
-
-# Minimum line length for functions/classes that require docstrings, shorter
-# ones are exempt.
-docstring-min-length=-1
+# Minimum lines number of a similarity.
+min-similarity-lines=4
 
 
 [MISCELLANEOUS]
 
 # List of note tags to take in consideration, separated by a comma.
-notes=FIXME,XXX,TODO
+notes=FIXME,
+      XXX
 
 
-[IMPORTS]
+[TYPECHECK]
 
-# Deprecated modules which should not be used, separated by a comma
-deprecated-modules=regsub,TERMIOS,Bastion,rexec
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
 
-# Create a graph of every (i.e. internal and external) dependencies in the
-# given file (report RP0402 must not be disabled)
-import-graph=
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
 
-# Create a graph of external dependencies in the given file (report RP0402 must
-# not be disabled)
-ext-import-graph=
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
 
-# Create a graph of internal dependencies in the given file (report RP0402 must
-# not be disabled)
-int-import-graph=
+# Tells whether to warn about missing members when the owner of the attribute
+# is inferred to be None.
+ignore-none=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis. It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+
+[LOGGING]
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format.
+logging-modules=logging
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid to define new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expected to
+# not be used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore.
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging  or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=100
+
+# Maximum number of lines in a module.
+max-module-lines=1000
+
+# List of optional constructs for which whitespace checking is disabled. `dict-
+# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
+# `trailing-comma` allows a space between comma and closing bracket: (a, ).
+# `empty-line` allows space-only lines.
+no-space-check=trailing-comma,
+               dict-separator
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes.
+max-spelling-suggestions=4
+
+# Spelling dictionary name. Available dictionaries: none. To make it working
+# install python-enchant package..
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method.
+max-args=5
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Maximum number of boolean expressions in an if statement.
+max-bool-expr=5
+
+# Maximum number of branch for function / method body.
+max-branches=12
+
+# Maximum number of locals for function / method body.
+max-locals=15
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body.
+max-returns=6
+
+# Maximum number of statements in function / method body.
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
 
 
 [CLASSES]
 
-# List of interface methods to ignore, separated by a comma. This is used for
-# instance to not check methods defines in Zope's Interface base class.
-ignore-iface-methods=isImplementedBy,deferred,extends,names,namesAndDescriptions,queryDescriptionFor,getBases,getDescriptionFor,getDoc,getName,getTaggedValue,getTaggedValueTags,isEqualOrExtendedBy,setTaggedValue,isImplementedByInstancesOf,adaptWith,is_implemented_by
-
 # List of method names used to declare (i.e. assign) instance attributes.
-defining-attr-methods=__init__,__new__,setUp
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,
+                  _fields,
+                  _replace,
+                  _source,
+                  _make
 
 # List of valid names for the first argument in a class method.
 valid-classmethod-first-arg=cls
 
 # List of valid names for the first argument in a metaclass class method.
-valid-metaclass-classmethod-first-arg=mcs
+valid-metaclass-classmethod-first-arg=cls
 
 
-[DESIGN]
+[IMPORTS]
 
-# Maximum number of arguments for function / method
-max-args=5
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
 
-# Argument names that match this expression will be ignored. Default to name
-# with leading underscore
-ignored-argument-names=_.*
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
 
-# Maximum number of locals for function / method body
-max-locals=20
+# Deprecated modules which should not be used, separated by a comma.
+deprecated-modules=optparse,tkinter.tix
 
-# Maximum number of return / yield for function / method body
-max-returns=6
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled).
+ext-import-graph=
 
-# Maximum number of branch for function / method body
-max-branches=15
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled).
+import-graph=
 
-# Maximum number of statements in function / method body
-max-statements=50
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled).
+int-import-graph=
 
-# Maximum number of parents for a class (see R0901).
-max-parents=7
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
 
-# Maximum number of attributes for a class (see R0902).
-max-attributes=20
-
-# Minimum number of public methods for a class (see R0903).
-min-public-methods=2
-
-# Maximum number of public methods for a class (see R0904).
-max-public-methods=40
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
 
 
 [EXCEPTIONS]
 
 # Exceptions that will emit a warning when being caught. Defaults to
-# "Exception"
+# "Exception".
 overgeneral-exceptions=Exception

--- a/.release
+++ b/.release
@@ -1,2 +1,2 @@
-release=0.0.0
-tag=lmcbaseclasses-0.0.0
+release=0.1.3
+tag=lmcbaseclasses-0.1.3

--- a/Makefile
+++ b/Makefile
@@ -133,8 +133,6 @@ test: build up ## test the application
 	  rm -fr build; \
 	  docker cp $(BUILD):/build .; \
 	  docker rm -f -v $(BUILD); \
-#	  docker logs $(CACHE_VOLUME); \
-#	  docker logs $(CACHE_VOLUME) > build/container.log 2>&1; \
 	  $(MAKE) down; \
 	  exit $$status
 
@@ -146,8 +144,6 @@ lint: build up ## lint the application (static code analysis)
 	  rm -fr build; \
 	  docker cp $(BUILD):/build .; \
 	  docker rm -f -v $(BUILD); \
-#	  docker logs $(CACHE_VOLUME); \
-#	  docker logs $(CACHE_VOLUME) > build/container.log 2>&1; \
 	  $(MAKE) down; \
 	  exit $$status
 

--- a/Makefile
+++ b/Makefile
@@ -138,6 +138,19 @@ test: build up ## test the application
 	  $(MAKE) down; \
 	  exit $$status
 
+lint: DOCKER_RUN_ARGS = --volumes-from=$(BUILD)
+lint: build up ## lint the application (static code analysis)
+	$(INIT_CACHE)
+	$(call make,lint); \
+	  status=$$?; \
+	  rm -fr build; \
+	  docker cp $(BUILD):/build .; \
+	  docker rm -f -v $(BUILD); \
+#	  docker logs $(CACHE_VOLUME); \
+#	  docker logs $(CACHE_VOLUME) > build/container.log 2>&1; \
+	  $(MAKE) down; \
+	  exit $$status
+
 pull:  ## download the application image
 	docker pull $(IMAGE_TO_TEST)
 

--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,7 @@ test: build up ## test the application
 	$(call make,test); \
 	  status=$$?; \
 	  docker cp $(BUILD):/build .; \
-	  docker rm -f -v $(BUILD); \
+	#   docker rm -f -v $(BUILD); \
 	  $(MAKE) down; \
 	  exit $$status
 
@@ -141,7 +141,7 @@ lint: build up ## lint the application (static code analysis)
 	$(call make,lint); \
 	  status=$$?; \
 	  docker cp $(BUILD):/build .; \
-	  docker rm -f -v $(BUILD); \
+	#   docker rm -f -v $(BUILD); \
 	  $(MAKE) down; \
 	  exit $$status
 

--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,6 @@ test: build up ## test the application
 	$(INIT_CACHE)
 	$(call make,test); \
 	  status=$$?; \
-	#   rm -fr build; \
 	  docker cp $(BUILD):/build .; \
 	  docker rm -f -v $(BUILD); \
 	  $(MAKE) down; \
@@ -141,7 +140,6 @@ lint: build up ## lint the application (static code analysis)
 	$(INIT_CACHE)
 	$(call make,lint); \
 	  status=$$?; \
-	#   rm -fr build; \
 	  docker cp $(BUILD):/build .; \
 	  docker rm -f -v $(BUILD); \
 	  $(MAKE) down; \

--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ test: build up ## test the application
 	$(INIT_CACHE)
 	$(call make,test); \
 	  status=$$?; \
-	  rm -fr build; \
+	#   rm -fr build; \
 	  docker cp $(BUILD):/build .; \
 	  docker rm -f -v $(BUILD); \
 	  $(MAKE) down; \
@@ -141,7 +141,7 @@ lint: build up ## lint the application (static code analysis)
 	$(INIT_CACHE)
 	$(call make,lint); \
 	  status=$$?; \
-	  rm -fr build; \
+	#   rm -fr build; \
 	  docker cp $(BUILD):/build .; \
 	  docker rm -f -v $(BUILD); \
 	  $(MAKE) down; \

--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,6 @@ test: build up ## test the application
 	$(call make,test); \
 	  status=$$?; \
 	  docker cp $(BUILD):/build .; \
-	#   docker rm -f -v $(BUILD); \
 	  $(MAKE) down; \
 	  exit $$status
 
@@ -141,7 +140,6 @@ lint: build up ## lint the application (static code analysis)
 	$(call make,lint); \
 	  status=$$?; \
 	  docker cp $(BUILD):/build .; \
-	#   docker rm -f -v $(BUILD); \
 	  $(MAKE) down; \
 	  exit $$status
 

--- a/Pipfile
+++ b/Pipfile
@@ -31,6 +31,7 @@ sphinxcontrib-websupport = "*"
 coverage  = "*"
 pytest-xdist = "*"
 mock = "*"
+pylint-junit = "*"
 
 [requires]
 python_version = "3"

--- a/code-analysis.sh
+++ b/code-analysis.sh
@@ -3,17 +3,6 @@ echo "STATIC CODE ANALYSIS"
 echo "===================="
 echo
 
-echo "MODULE ANALYSIS"
-echo "---------------"
-pylint --rcfile=.pylintrc skabase
-
-echo "TESTS ANALYSIS"
-echo "--------------"
-pylint --rcfile=.pylintrc skabase/SKAAlarmHandler/test
-pylint --rcfile=.pylintrc skabase/SKABaseDevice/test
-pylint --rcfile=.pylintrc skabase/SKACapability/test
-pylint --rcfile=.pylintrc skabase/SKALogger/test
-pylint --rcfile=.pylintrc skabase/SKAMaster/test
-pylint --rcfile=.pylintrc skabase/SKAObsDevice/test
-pylint --rcfile=.pylintrc skabase/SKASubarray/test
-pylint --rcfile=.pylintrc skabase/SKATelState/test
+# FIXME pylint needs to run twice since there is no way go gather the text and xml output at the same time
+pylint -f colorized skabase
+pylint skabase > lint_output.xml

--- a/code-analysis.sh
+++ b/code-analysis.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-echo "STATIC CODE ANALYSIS"
-echo "===================="
-echo
-
-# FIXME pylint needs to run twice since there is no way go gather the text and xml output at the same time
-pylint -f colorized skabase
-pylint skabase > lint_output.xml

--- a/test-harness/Makefile
+++ b/test-harness/Makefile
@@ -21,7 +21,7 @@ test:
 	retry --max=10 -- tango_admin --ping-device ska/subarray/01
 	retry --max=10 -- tango_admin --ping-device ska/telstate/01
 
-	cd /app && python setup.py test | tee setup_py_test.stdout
+	cd /app && python setup.py test | tee setup_py_test.stdout; \
 	if [ -d /build ]; then \
 		mv /app/setup_py_test.stdout /build/lmcbaseclasses_setup_py_test.stdout; \
 		mv /app/htmlcov /build/lmcbaseclasses_htmlcov; \

--- a/test-harness/Makefile
+++ b/test-harness/Makefile
@@ -5,7 +5,7 @@
 SHELL = /bin/bash
 .SHELLFLAGS = -o pipefail -c
 
-all: test
+all: test lint
 
 # wait for the device to be available before beginning the test
 # A temporary volume is mounted at /build when 'make test' is executing.
@@ -22,12 +22,31 @@ test:
 	retry --max=10 -- tango_admin --ping-device ska/telstate/01
 
 	cd /app && python setup.py test | tee setup_py_test.stdout
-	cd /app && ./code-analysis.sh | tee code_analysis.stdout
 	if [ -d /build ]; then \
 		mv /app/setup_py_test.stdout /build/lmcbaseclasses_setup_py_test.stdout; \
-		mv /app/code_analysis.stdout /build/lmcbaseclasses_code_analysis.stdout; \
 		mv /app/htmlcov /build/lmcbaseclasses_htmlcov; \
 		mv /app/coverage.xml /build/lmcbaseclasses_coverage.xml; \
 	fi;
 
-.PHONY: all test
+# wait for the device to be available before beginning the test
+# A temporary volume is mounted at /build when 'make test' is executing.
+# The following steps copy across useful output to this volume which can
+# then be extracted to form the CI summary for the test procedure.
+lint:
+	retry --max=10 -- tango_admin --ping-device ska/basedevice/01
+	retry --max=10 -- tango_admin --ping-device ska/alarmhandler/01
+	retry --max=10 -- tango_admin --ping-device ska/capability/01
+	retry --max=10 -- tango_admin --ping-device ska/logger/01
+	retry --max=10 -- tango_admin --ping-device ska/master/01
+	retry --max=10 -- tango_admin --ping-device ska/obsdevice/01
+	retry --max=10 -- tango_admin --ping-device ska/subarray/01
+	retry --max=10 -- tango_admin --ping-device ska/telstate/01
+
+	cd /app && ./code-analysis.sh | tee code_analysis.stdout
+	if [ -d /build ]; then \
+		mv /app/code_analysis.stdout /build/lmcbaseclasses_code_analysis.stdout; \
+		mv /app/htmlcov /build/lmcbaseclasses_htmlcov; \
+		mv /app/lint_output.xml /build/lint_output.xml; \
+	fi;
+
+.PHONY: all test lint

--- a/test-harness/Makefile
+++ b/test-harness/Makefile
@@ -42,10 +42,11 @@ lint:
 	retry --max=10 -- tango_admin --ping-device ska/subarray/01
 	retry --max=10 -- tango_admin --ping-device ska/telstate/01
 
-	cd /app && ./code-analysis.sh | tee code_analysis.stdout
+	# FIXME pylint needs to run twice since there is no way go gather the text and junit xml output at the same time
+	cd /app && pylint -f colorized skabase | tee code_analysis.stdout; \
+	cd /app && pylint skabase > lint_output.xml; \
 	if [ -d /build ]; then \
 		mv /app/code_analysis.stdout /build/lmcbaseclasses_code_analysis.stdout; \
-		mv /app/htmlcov /build/lmcbaseclasses_htmlcov; \
 		mv /app/lint_output.xml /build/lint_output.xml; \
 	fi;
 


### PR DESCRIPTION
## Main work

The main work done here was to add a separate stage for the **linting** process in the CI and to extract the linting information in an XML with JUnit format.

1. The release was updated to the latest version (there was a bug).
2. Pylint standards were updated to sensible choices on par on what is used on other big open source projects (i.e. Microsoft).
3. Makefile has been added a new functionality: _lint_

## Major outstanding issues

There are a number of outstanding issues with this repository there were not part of this PI feature but should be addressed in the near future. Below I list the two ones that seem the most urgent.

1. Linting process reports several warnings and some errors. These must be actually fixed in the source code and not by adding an exception not to check for the error under `.pylintrc`
2. The namespace of the `lmc-base-classes` needs to be fixed.



